### PR TITLE
Criação de API para validar CPF RESOLVE #198

### DIFF
--- a/Codigo/Core/Service/IClienteService.cs
+++ b/Codigo/Core/Service/IClienteService.cs
@@ -4,12 +4,10 @@ namespace Core.Service;
 
 public interface IClienteService
 {
-    //esses dois se referem ao caso de uso autenticar cliente
     uint Create(Cliente cliente);
 
     Cliente? Get(uint id);
 
-    //esses dois metodos sao para o caso de uso manter perfil
     void Edit(Cliente cliente);
 
     void Delete(uint id);
@@ -25,4 +23,9 @@ public interface IClienteService
     /// Busca um cliente pelo telefone para autenticação
     /// </summary>
     Cliente? GetByTelefone(string telefone);
+
+    /// <summary>
+    /// Busca um cliente pelo CPF
+    /// </summary>
+    Task<Cliente?> GetByCpf(string cpf);
 }

--- a/Codigo/DeliFitWeb/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Codigo/DeliFitWeb/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -19,184 +19,213 @@ using Microsoft.Extensions.Logging;
 using Core;
 using Core.Service;
 
-namespace DeliFitWeb.Areas.Identity.Pages.Account
+namespace DeliFitWeb.Areas.Identity.Pages.Account;
+
+public class RegisterModel : PageModel
 {
-    public class RegisterModel : PageModel
+    private readonly SignInManager<UsuarioIdentity> _signInManager;
+    private readonly UserManager<UsuarioIdentity> _userManager;
+    private readonly IUserStore<UsuarioIdentity> _userStore;
+    private readonly IUserEmailStore<UsuarioIdentity> _emailStore;
+    private readonly ILogger<RegisterModel> _logger;
+    private readonly IEmailSender _emailSender;
+    private readonly IClienteService _clienteService;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public RegisterModel(
+        UserManager<UsuarioIdentity> userManager,
+        IUserStore<UsuarioIdentity> userStore,
+        SignInManager<UsuarioIdentity> signInManager,
+        ILogger<RegisterModel> logger,
+        IEmailSender emailSender,
+        IClienteService clienteService,
+        IHttpClientFactory httpClientFactory)
     {
-        private readonly SignInManager<UsuarioIdentity> _signInManager;
-        private readonly UserManager<UsuarioIdentity> _userManager;
-        private readonly IUserStore<UsuarioIdentity> _userStore;
-        private readonly IUserEmailStore<UsuarioIdentity> _emailStore;
-        private readonly ILogger<RegisterModel> _logger;
-        private readonly IEmailSender _emailSender;
-        private readonly IClienteService _clienteService;
+        _userManager = userManager;
+        _userStore = userStore;
+        _emailStore = GetEmailStore();
+        _signInManager = signInManager;
+        _logger = logger;
+        _emailSender = emailSender;
+        _clienteService = clienteService;
+        _httpClientFactory = httpClientFactory;
+    }
 
-        public RegisterModel(
-            UserManager<UsuarioIdentity> userManager,
-            IUserStore<UsuarioIdentity> userStore,
-            SignInManager<UsuarioIdentity> signInManager,
-            ILogger<RegisterModel> logger,
-            IEmailSender emailSender,
-            IClienteService clienteService)
+    [BindProperty]
+    public InputModel Input { get; set; }
+
+    public string ReturnUrl { get; set; }
+
+    public IList<AuthenticationScheme> ExternalLogins { get; set; }
+
+    public class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Email")]
+        public string Email { get; set; }
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        public string Password { get; set; }
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+        public string ConfirmPassword { get; set; }
+
+        [Display(Name = "Tipo de Perfil")]
+        public string RoleDesejada { get; set; }
+
+        // Campos extras para cadastro de Cliente
+        [Display(Name = "Nome completo")]
+        public string Nome { get; set; }
+
+        [Display(Name = "CPF")]
+        public string Cpf { get; set; }
+
+        [Display(Name = "Telefone")]
+        public string Telefone { get; set; }
+
+        [Display(Name = "Data de Nascimento")]
+        [DataType(DataType.Date)]
+        public DateTime? DataNascimento { get; set; }
+    }
+
+    public async Task OnGetAsync(string returnUrl = null, string role = null)
+    {
+        ReturnUrl = returnUrl;
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+        Input ??= new InputModel();
+        Input.RoleDesejada ??= string.IsNullOrEmpty(role) ? "Cliente" : role;
+    }
+
+    public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+    {
+        returnUrl ??= Url.Content("~/");
+        ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+        // Validações extras para role Cliente
+        if (Input.RoleDesejada == "Cliente")
         {
-            _userManager = userManager;
-            _userStore = userStore;
-            _emailStore = GetEmailStore();
-            _signInManager = signInManager;
-            _logger = logger;
-            _emailSender = emailSender;
-            _clienteService = clienteService;
-        }
+            if (string.IsNullOrWhiteSpace(Input.Nome))
+                ModelState.AddModelError("Input.Nome", "O nome é obrigatório.");
+            if (string.IsNullOrWhiteSpace(Input.Cpf))
+                ModelState.AddModelError("Input.Cpf", "O CPF é obrigatório.");
+            if (string.IsNullOrWhiteSpace(Input.Telefone))
+                ModelState.AddModelError("Input.Telefone", "O telefone é obrigatório.");
+            if (Input.DataNascimento == null)
+                ModelState.AddModelError("Input.DataNascimento", "A data de nascimento é obrigatória.");
 
-        [BindProperty]
-        public InputModel Input { get; set; }
-
-        public string ReturnUrl { get; set; }
-
-        public IList<AuthenticationScheme> ExternalLogins { get; set; }
-
-        public class InputModel
-        {
-            [Required]
-            [EmailAddress]
-            [Display(Name = "Email")]
-            public string Email { get; set; }
-
-            [Required]
-            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
-            [DataType(DataType.Password)]
-            [Display(Name = "Password")]
-            public string Password { get; set; }
-
-            [DataType(DataType.Password)]
-            [Display(Name = "Confirm password")]
-            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
-            public string ConfirmPassword { get; set; }
-
-            [Display(Name = "Tipo de Perfil")]
-            public string RoleDesejada { get; set; }
-
-            // Campos extras para cadastro de Cliente
-            [Display(Name = "Nome completo")]
-            public string Nome { get; set; }
-
-            [Display(Name = "CPF")]
-            public string Cpf { get; set; }
-
-            [Display(Name = "Telefone")]
-            public string Telefone { get; set; }
-
-            [Display(Name = "Data de Nascimento")]
-            [DataType(DataType.Date)]
-            public DateTime? DataNascimento { get; set; }
-        }
-
-        public async Task OnGetAsync(string returnUrl = null, string role = null)
-        {
-            ReturnUrl = returnUrl;
-            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
-            Input ??= new InputModel();
-            Input.RoleDesejada ??= string.IsNullOrEmpty(role) ? "Cliente" : role;
-        }
-
-        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
-        {
-            returnUrl ??= Url.Content("~/");
-            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
-
-            // Validações extras para role Cliente
-            if (Input.RoleDesejada == "Cliente")
+            // Valida o CPF via API antes de prosseguir
+            if (!string.IsNullOrWhiteSpace(Input.Cpf))
             {
-                if (string.IsNullOrWhiteSpace(Input.Nome))
-                    ModelState.AddModelError("Input.Nome", "O nome é obrigatório.");
-                if (string.IsNullOrWhiteSpace(Input.Cpf))
-                    ModelState.AddModelError("Input.Cpf", "O CPF é obrigatório.");
-                if (string.IsNullOrWhiteSpace(Input.Telefone))
-                    ModelState.AddModelError("Input.Telefone", "O telefone é obrigatório.");
-                if (Input.DataNascimento == null)
-                    ModelState.AddModelError("Input.DataNascimento", "A data de nascimento é obrigatória.");
+                var cpfValido = await ValidarCpfViaApiAsync(Input.Cpf);
+                if (!cpfValido)
+                    ModelState.AddModelError("Input.Cpf", "CPF inválido. Verifique os dígitos informados.");
             }
+        }
 
-            if (ModelState.IsValid)
+        if (ModelState.IsValid)
+        {
+            var user = CreateUser();
+
+            await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+            await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+            var result = await _userManager.CreateAsync(user, Input.Password);
+
+            if (result.Succeeded)
             {
-                var user = CreateUser();
+                _logger.LogInformation("User created a new account with password.");
 
-                await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
-                await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
-                var result = await _userManager.CreateAsync(user, Input.Password);
+                await _userManager.AddToRoleAsync(user, Input.RoleDesejada);
 
-                if (result.Succeeded)
+                // Se for cliente, cria o registro na tabela Cliente
+                if (Input.RoleDesejada == "Cliente")
                 {
-                    _logger.LogInformation("User created a new account with password.");
-
-                    await _userManager.AddToRoleAsync(user, Input.RoleDesejada);
-
-                    // Se for cliente, cria o registro na tabela Cliente
-                    if (Input.RoleDesejada == "Cliente")
+                    var cliente = new Cliente
                     {
-                        var cliente = new Cliente
-                        {
-                            Nome = Input.Nome,
-                            Email = Input.Email,
-                            Cpf = Input.Cpf,
-                            Telefone = Input.Telefone,
-                            DataNascimento = Input.DataNascimento!.Value
-                        };
-                        _clienteService.Create(cliente);
-                    }
-
-                    var userId = await _userManager.GetUserIdAsync(user);
-                    var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-                    code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-                    var callbackUrl = Url.Page(
-                        "/Account/ConfirmEmail",
-                        pageHandler: null,
-                        values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
-                        protocol: Request.Scheme);
-
-                    await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
-                        $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
-
-                    if (_userManager.Options.SignIn.RequireConfirmedAccount)
-                    {
-                        return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
-                    }
-                    else
-                    {
-                        await _signInManager.SignInAsync(user, isPersistent: false);
-                        return LocalRedirect(returnUrl);
-                    }
+                        Nome = Input.Nome,
+                        Email = Input.Email,
+                        Cpf = Input.Cpf,
+                        Telefone = Input.Telefone,
+                        DataNascimento = Input.DataNascimento!.Value
+                    };
+                    _clienteService.Create(cliente);
                 }
-                foreach (var error in result.Errors)
+
+                var userId = await _userManager.GetUserIdAsync(user);
+                var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                var callbackUrl = Url.Page(
+                    "/Account/ConfirmEmail",
+                    pageHandler: null,
+                    values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                    protocol: Request.Scheme);
+
+                await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
+                    $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+
+                if (_userManager.Options.SignIn.RequireConfirmedAccount)
                 {
-                    ModelState.AddModelError(string.Empty, error.Description);
+                    return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
+                }
+                else
+                {
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    return LocalRedirect(returnUrl);
                 }
             }
-
-            return Page();
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
         }
 
-        private UsuarioIdentity CreateUser()
+        return Page();
+    }
+
+    /// <summary>
+    /// Consome a própria API de CPF para validar os dígitos verificadores.
+    /// Retorna true se válido, false caso contrário.
+    /// </summary>
+    private async Task<bool> ValidarCpfViaApiAsync(string cpf)
+    {
+        try
         {
-            try
-            {
-                return Activator.CreateInstance<UsuarioIdentity>();
-            }
-            catch
-            {
-                throw new InvalidOperationException($"Can't create an instance of '{nameof(UsuarioIdentity)}'. " +
-                    $"Ensure that '{nameof(UsuarioIdentity)}' is not an abstract class and has a parameterless constructor, or alternatively " +
-                    $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
-            }
+            var client = _httpClientFactory.CreateClient("CpfApi");
+            var response = await client.GetAsync($"/api/cpf/{cpf}/validar");
+            return response.IsSuccessStatusCode;
         }
-
-        private IUserEmailStore<UsuarioIdentity> GetEmailStore()
+        catch
         {
-            if (!_userManager.SupportsUserEmail)
-            {
-                throw new NotSupportedException("The default UI requires a user store with email support.");
-            }
-            return (IUserEmailStore<UsuarioIdentity>)_userStore;
+            // Se a API estiver indisponível, bloqueia o cadastro por segurança
+            return false;
         }
+    }
+
+    private UsuarioIdentity CreateUser()
+    {
+        try
+        {
+            return Activator.CreateInstance<UsuarioIdentity>();
+        }
+        catch
+        {
+            throw new InvalidOperationException($"Can't create an instance of '{nameof(UsuarioIdentity)}'. " +
+                $"Ensure that '{nameof(UsuarioIdentity)}' is not an abstract class and has a parameterless constructor, or alternatively " +
+                $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
+        }
+    }
+
+    private IUserEmailStore<UsuarioIdentity> GetEmailStore()
+    {
+        if (!_userManager.SupportsUserEmail)
+        {
+            throw new NotSupportedException("The default UI requires a user store with email support.");
+        }
+        return (IUserEmailStore<UsuarioIdentity>)_userStore;
     }
 }

--- a/Codigo/DeliFitWeb/Controllers/ClienteController.cs
+++ b/Codigo/DeliFitWeb/Controllers/ClienteController.cs
@@ -15,12 +15,6 @@ namespace DeliFitWeb.Controllers
         private readonly IMapper _mapper;
         private readonly UserManager<UsuarioIdentity> _userManager;
 
-        public ClienteController(IClienteService clienteService, IMapper mapper)
-        {
-            _clienteService = clienteService;
-            _mapper = mapper;
-        }
-
         public ClienteController(IClienteService clienteService, IMapper mapper, UserManager<UsuarioIdentity> userManager)
         {
             _clienteService = clienteService;

--- a/Codigo/DeliFitWeb/Controllers/CpfApiController.cs
+++ b/Codigo/DeliFitWeb/Controllers/CpfApiController.cs
@@ -1,0 +1,55 @@
+﻿using Core.Service;
+using Microsoft.AspNetCore.Mvc;
+using Util;
+
+namespace DeliFitWeb.Controllers.Api
+{
+    [ApiController]
+    [Route("api/cpf")]
+    public class CpfApiController : ControllerBase
+    {
+        private readonly IClienteService _clienteService;
+
+        public CpfApiController(IClienteService clienteService)
+        {
+            _clienteService = clienteService;
+        }
+
+        /// <summary>
+        /// Valida o formato e os dígitos verificadores de um CPF.
+        /// GET /api/cpf/{cpf}/validar/
+        /// </summary>
+        [HttpGet("{cpf}/validar")]
+        public async Task<IActionResult> Validar(string cpf)
+        {
+            var cpfLimpo = Methods.RemoveNaoNumericos(cpf);
+            var valido = Methods.ValidarCpf(cpfLimpo);
+
+            if (!valido)
+                return BadRequest();
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Verifica se um CPF já está cadastrado na base de dados.
+        /// GET /api/cpf/{cpf}
+        /// </summary>
+        [HttpGet("{cpf}")]
+        public async Task<IActionResult> Existe(string cpf)
+        {
+            var cpfLimpo = Methods.RemoveNaoNumericos(cpf);
+
+            var valido = Methods.ValidarCpf(cpfLimpo);
+            if (!valido)
+                return BadRequest(new { cpf = cpfLimpo, valido = false, mensagem = "CPF inválido." });
+
+            var cliente = await _clienteService.GetByCpf(cpfLimpo);
+
+            if (cliente == null)
+                return NotFound();
+
+            return Ok();
+        }
+    }
+}

--- a/Codigo/DeliFitWeb/Program.cs
+++ b/Codigo/DeliFitWeb/Program.cs
@@ -31,7 +31,7 @@ public class Program
             options.UseMySQL(builder.Configuration.GetConnectionString("IdentityConnection")));
 
         builder.Services.AddDefaultIdentity<UsuarioIdentity>(options =>
-        { 
+        {
             options.SignIn.RequireConfirmedAccount = false;
             options.SignIn.RequireConfirmedEmail = false;
             options.SignIn.RequireConfirmedPhoneNumber = false;
@@ -71,16 +71,26 @@ public class Program
         builder.Services.AddTransient<ICartaoService, CartaoService>();
         builder.Services.AddTransient<ICarrinhoService, CarrinhoService>();
 
+        // Registra o HttpClient nomeado para consumo da própria API de CPF
+        builder.Services.AddHttpClient("CpfApi", client =>
+        {
+            client.BaseAddress = new Uri("https://localhost:44309");
+        }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            // Permite certificado autoassinado em desenvolvimento
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        });
+
         builder.Services.ConfigureApplicationCookie(options =>
-                {
-                    //options.AccessDeniedPath = "/Identity/Autenticar";
-                    options.Cookie.Name = "DeliFitCookieName";
-                    options.Cookie.HttpOnly = true;
-                    options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
-                    //options.LoginPath = "/Identity/Autenticar";
-                    // ReturnUrlParameter requires 
-                    options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
-                    options.SlidingExpiration = true;
+        {
+            //options.AccessDeniedPath = "/Identity/Autenticar";
+            options.Cookie.Name = "DeliFitCookieName";
+            options.Cookie.HttpOnly = true;
+            options.ExpireTimeSpan = TimeSpan.FromMinutes(60);
+            //options.LoginPath = "/Identity/Autenticar";
+            // ReturnUrlParameter requires 
+            options.ReturnUrlParameter = CookieAuthenticationDefaults.ReturnUrlParameter;
+            options.SlidingExpiration = true;
         });
 
 
@@ -106,7 +116,7 @@ public class Program
             app.UseHsts();
         }
 
-        
+
 
 
         app.UseHttpsRedirection();
@@ -147,5 +157,5 @@ public class Program
 
         app.Run();
     }
-    
+
 }

--- a/Codigo/Service/ClienteService.cs
+++ b/Codigo/Service/ClienteService.cs
@@ -2,10 +2,8 @@ using Core;
 using Core.DTO;
 using Core.Service;
 using Microsoft.EntityFrameworkCore;
-using MySqlX.XDevAPI;
 
 namespace Service;
-
 
 /// <summary>
 /// Implementa os serviços para manter os dados de clientes
@@ -19,11 +17,6 @@ public class ClienteService : IClienteService
         _context = context;
     }
 
-    /// <summary>
-    /// Cria um novo cliente na base de dados
-    /// </summary>
-    /// <param name="cliente">dados do cliente</param>
-    /// <returns>id do novo cliente</returns>
     public uint Create(Cliente cliente)
     {
         _context.Add(cliente);
@@ -31,37 +24,24 @@ public class ClienteService : IClienteService
         return cliente.Id;
     }
 
-    /// <summary>
-    /// Obter os dados de um cliente da base de dados
-    /// </summary>
-    /// <param name="id">id do cliente</param>
-    /// <returns>dados do cliente</returns>
     public Cliente? Get(uint id)
     {
         return _context.Clientes
-                    .FirstOrDefault(a => a.Id == id);
+            .FirstOrDefault(a => a.Id == id);
     }
 
-    /// <summary>
-    /// Atualizar dados de um cliente da base de dados
-    /// </summary>
-    /// <param name="cliente">novos dados do cliente</param>
     public void Edit(Cliente cliente)
     {
         _context.Update(cliente);
         _context.SaveChanges();
     }
 
-    /// <summary>
-    /// Remover dados de um cliente da base de dados
-    /// </summary>
-    /// <param name="id">id do cliente</param>
     public void Delete(uint id)
     {
-        var Cliente = _context.Clientes.FirstOrDefault(a => a.Id == id);
-        if (Cliente != null)
+        var cliente = _context.Clientes.FirstOrDefault(a => a.Id == id);
+        if (cliente != null)
         {
-            _context.Clientes.Remove(Cliente);
+            _context.Clientes.Remove(cliente);
             _context.SaveChanges();
         }
         else
@@ -70,10 +50,6 @@ public class ClienteService : IClienteService
         }
     }
 
-    /// <summary>
-    /// Obter dados de todos os clientes da base de dados
-    /// </summary>
-    /// <returns>dados dos clientes</returns>
     public IEnumerable<ClienteDTO> GetAll()
     {
         return _context.Clientes
@@ -90,8 +66,6 @@ public class ClienteService : IClienteService
     /// <summary>
     /// Busca um cliente pelo e-mail para autenticação
     /// </summary>
-    /// <param name="email">e-mail do cliente</param>
-    /// <returns>dados do cliente ou null</returns>
     public Cliente? GetByEmail(string email)
     {
         return _context.Clientes
@@ -101,11 +75,18 @@ public class ClienteService : IClienteService
     /// <summary>
     /// Busca um cliente pelo telefone para autenticação
     /// </summary>
-    /// <param name="telefone">telefone do cliente</param>
-    /// <returns>dados do cliente ou null</returns>
     public Cliente? GetByTelefone(string telefone)
     {
         return _context.Clientes
             .FirstOrDefault(c => c.Telefone == telefone);
+    }
+
+    /// <summary>
+    /// Busca um cliente pelo CPF de forma assíncrona
+    /// </summary>
+    public async Task<Cliente?> GetByCpf(string cpf)
+    {
+        return await _context.Clientes
+            .FirstOrDefaultAsync(c => c.Cpf == cpf);
     }
 }


### PR DESCRIPTION
Criada a API para validação de cpf que será consumida durante o cadastro de cliente, verificando se a quantidade de digitos colocada pelo usuário corresponde à quantidade válida e se aquele cpf já não está sendo utilizado por outra conta.